### PR TITLE
Add Open4::pfork4 for executing arbitrary Ruby code

### DIFF
--- a/README
+++ b/README
@@ -193,6 +193,44 @@ SAMPLES
     42
     /dmsp/reference/ruby-1.8.1//lib/ruby/1.8/timeout.rb:42:in `relay': execution expired (Timeout::Error)
 
+  ----------------------------------------------------------------------------
+  pfork4 is similar to popen4, but instead of executing a command, it runs
+  ruby code in a child process. if the child process raises an exception, it
+  propagates to the parent.
+  ----------------------------------------------------------------------------
+
+    harp: > cat sample/pfork4.rb
+    require 'open4'
+
+    echo = lambda do
+      $stdout.write $stdin.read
+      raise 'finish implementing me'
+    end
+
+    org_message = "hello, world!"
+    got_message = nil
+    exception   = nil
+
+    begin
+      Open4.pfork4(echo) do |cid, stdin, stdout, stderr|
+        stdin.write org_message
+        stdin.close
+        got_message = stdout.read
+      end
+    rescue RuntimeError => e
+      exception = e.to_s
+    end
+
+    puts "org_message: #{org_message}"
+    puts "got_message: #{got_message}"
+    puts "exception  : #{exception}"
+
+
+    harp: > ruby sample/pfork4.rb
+    org_message: hello, world!
+    got_message: hello, world!
+    exception  : finish implementing me
+
 HISTORY
   1.0.0
     - added ability for spawn to take a proc (respond_to?(:call))

--- a/README.erb
+++ b/README.erb
@@ -193,6 +193,44 @@ SAMPLES
     42
     /dmsp/reference/ruby-1.8.1//lib/ruby/1.8/timeout.rb:42:in `relay': execution expired (Timeout::Error)
 
+  ----------------------------------------------------------------------------
+  pfork4 is similar to popen4, but instead of executing a command, it runs
+  ruby code in a child process. if the child process raises an exception, it
+  propagates to the parent.
+  ----------------------------------------------------------------------------
+
+    harp: > cat sample/pfork4.rb
+    require 'open4'
+
+    echo = lambda do
+      $stdout.write $stdin.read
+      raise 'finish implementing me'
+    end
+
+    org_message = "hello, world!"
+    got_message = nil
+    exception   = nil
+
+    begin
+      Open4.pfork4(echo) do |cid, stdin, stdout, stderr|
+        stdin.write org_message
+        stdin.close
+        got_message = stdout.read
+      end
+    rescue RuntimeError => e
+      exception = e.to_s
+    end
+
+    puts "org_message: #{org_message}"
+    puts "got_message: #{got_message}"
+    puts "exception  : #{exception}"
+
+
+    harp: > ruby sample/pfork4.rb
+    org_message: hello, world!
+    got_message: hello, world!
+    exception  : finish implementing me
+
 HISTORY
   1.0.0
     - added ability for spawn to take a proc (respond_to?(:call))

--- a/Rakefile
+++ b/Rakefile
@@ -9,19 +9,8 @@ task :default do
 end
 
 task :test do
-  run_tests!
-end
-
-namespace :test do
-  task(:unit){ run_tests!(:unit) }
-  task(:functional){ run_tests!(:functional) }
-  task(:integration){ run_tests!(:integration) }
-end
-
-def run_tests!(which = nil)
-  which ||= '**'
   test_dir = File.join(This.dir, "test")
-  test_glob ||= File.join(test_dir, "#{ which }/**_test.rb")
+  test_glob ||= File.join(test_dir, "/**_test.rb")
   test_rbs = Dir.glob(test_glob).sort
         
   div = ('=' * 119)
@@ -29,7 +18,7 @@ def run_tests!(which = nil)
 
   test_rbs.each_with_index do |test_rb, index|
     testno = index + 1
-    command = "#{ This.ruby } -I ./lib -I ./test/lib #{ test_rb }"
+    command = "#{ This.ruby } -rubygems -I ./lib -I ./test/support #{ test_rb }"
 
     puts
     say(div, :color => :cyan, :bold => true)

--- a/lib/open4.rb
+++ b/lib/open4.rb
@@ -9,14 +9,41 @@ module Open4
 
   class Error < ::StandardError; end
 
+  def pfork4(fun, &b)
+    Open4.do_popen(b, :block) do |ps_read, _|
+      ps_read.close
+      begin
+        fun.call
+      rescue SystemExit => e
+        # Make it seem to the caller that calling Kernel#exit in +fun+ kills
+        # the child process normally. Kernel#exit! bypasses this rescue
+        # block.
+        exit! e.status
+      else
+        exit! 0
+      end
+    end
+  end
+  module_function :pfork4
+
   def popen4(*cmd, &b)
+    Open4.do_popen(b, :init) do |ps_read, ps_write|
+      ps_read.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+      ps_write.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+      exec(*cmd)
+      raise 'forty-two'   # Is this really needed?
+    end
+  end
+  alias open4 popen4
+  module_function :popen4
+  module_function :open4
+
+  def self.do_popen(b = nil, exception_propagation_at = nil, &cmd)
     pw, pr, pe, ps = IO.pipe, IO.pipe, IO.pipe, IO.pipe
 
     verbose = $VERBOSE
     begin
       $VERBOSE = nil
-      ps.first.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
-      ps.last.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
 
       cid = fork {
         pw.last.close
@@ -34,48 +61,53 @@ module Open4
         STDOUT.sync = STDERR.sync = true
 
         begin
-          exec(*cmd)
-          raise 'forty-two' 
+          cmd.call(ps)
         rescue Exception => e
           Marshal.dump(e, ps.last)
           ps.last.flush
+        ensure
+          ps.last.close unless ps.last.closed?
         end
-        ps.last.close unless (ps.last.closed?)
+
         exit!
       }
     ensure
       $VERBOSE = verbose
     end
 
-    [pw.first, pr.last, pe.last, ps.last].each{|fd| fd.close}
+    [ pw.first, pr.last, pe.last, ps.last ].each { |fd| fd.close }
 
-    begin
-      e = Marshal.load ps.first
-      raise(Exception === e ? e : "unknown failure!")
-    rescue EOFError # If we get an EOF error, then the exec was successful
-      42
-    ensure
-      ps.first.close
-    end
+    Open4.propagate_exception ps.first if exception_propagation_at == :init
 
     pw.last.sync = true
 
-    pi = [pw.last, pr.first, pe.first]
+    pi = [ pw.last, pr.first, pe.first ]
 
-    if b 
+    begin
+      return [cid, *pi] unless b
+
       begin
-        b[cid, *pi]
-        Process.waitpid2(cid).last
+        b.call(cid, *pi)
       ensure
-        pi.each{|fd| fd.close unless fd.closed?}
+        pi.each { |fd| fd.close unless fd.closed? }
       end
-    else
-      [cid, pw.last, pr.first, pe.first]
+
+      Open4.propagate_exception ps.first if exception_propagation_at == :block
+
+      Process.waitpid2(cid).last
+    ensure
+      ps.first.close unless ps.first.closed?
     end
   end
-  alias open4 popen4
-  module_function :popen4
-  module_function :open4
+
+  def self.propagate_exception(ps_read)
+    e = Marshal.load ps_read
+    raise Exception === e ? e : "unknown failure!"
+  rescue EOFError
+    # Child process did not raise exception.
+  ensure
+    ps_read.close
+  end
 
   class SpawnError < Error
     attr 'cmd'

--- a/rakefile
+++ b/rakefile
@@ -9,19 +9,8 @@ task :default do
 end
 
 task :test do
-  run_tests!
-end
-
-namespace :test do
-  task(:unit){ run_tests!(:unit) }
-  task(:functional){ run_tests!(:functional) }
-  task(:integration){ run_tests!(:integration) }
-end
-
-def run_tests!(which = nil)
-  which ||= '**'
   test_dir = File.join(This.dir, "test")
-  test_glob ||= File.join(test_dir, "#{ which }/**_test.rb")
+  test_glob ||= File.join(test_dir, "/**_test.rb")
   test_rbs = Dir.glob(test_glob).sort
         
   div = ('=' * 119)
@@ -29,7 +18,7 @@ def run_tests!(which = nil)
 
   test_rbs.each_with_index do |test_rb, index|
     testno = index + 1
-    command = "#{ This.ruby } -I ./lib -I ./test/lib #{ test_rb }"
+    command = "#{ This.ruby } -rubygems -I ./lib -I ./test/support #{ test_rb }"
 
     puts
     say(div, :color => :cyan, :bold => true)

--- a/samples/pfork4.rb
+++ b/samples/pfork4.rb
@@ -1,0 +1,24 @@
+require 'open4'
+
+echo = lambda do
+  $stdout.write $stdin.read
+  raise 'finish implementing me'
+end
+
+org_message = "hello, world!"
+got_message = nil
+exception   = nil
+
+begin
+  Open4.pfork4(echo) do |cid, stdin, stdout, stderr|
+    stdin.write org_message
+    stdin.close
+    got_message = stdout.read
+  end
+rescue RuntimeError => e
+  exception = e.to_s
+end
+
+puts "org_message: #{org_message}"
+puts "got_message: #{got_message}"
+puts "exception  : #{exception}"

--- a/test/pfork4_test.rb
+++ b/test/pfork4_test.rb
@@ -1,0 +1,144 @@
+require 'test_case'
+
+module Open4
+
+class PFork4Test < TestCase
+  def test_fun_successful_return
+    fun = lambda { 'lucky me' }
+    cid, _ = pfork4 fun
+    assert_equal 0, wait_status(cid)
+  end
+
+  def test_fun_force_exit
+    exit_code = 43
+    fun = lambda { exit! exit_code }
+    cid, _ = pfork4 fun
+    assert_equal exit_code, wait_status(cid)
+  end
+
+  def test_fun_normal_exit
+    exit_code = 43
+    fun = lambda { exit exit_code }
+    cid, _ = pfork4 fun
+    assert_equal exit_code, wait_status(cid)
+  end
+
+  def test_fun_does_not_propagate_exception_without_block
+    fun = lambda { raise MyError }
+    cid, _ = pfork4 fun
+    refute_equal 0, wait_status(cid)
+  end
+
+  def test_fun_propagate_exception_with_block
+    fun = lambda { raise MyError }
+    assert_raises(MyError) { pfork4(fun) {} }
+  end
+
+  def test_call_block_upon_exception
+    fun = lambda { raise MyError }
+    block_called = false
+    assert_raises(MyError) { pfork4(fun) { block_called = true } }
+    assert_equal true, block_called
+  end
+
+  def test_passes_child_pid_to_block
+    fun = lambda { $stdout.write Process.pid }
+    cid_in_block = nil
+    cid_in_fun = nil
+    status = pfork4(fun) do |cid, _, stdout, _|
+      cid_in_block = cid
+      cid_in_fun = stdout.read.to_i
+    end
+    assert_equal cid_in_fun, cid_in_block
+  end
+
+  def test_io_pipes_without_block
+    via_msg = 'foo'
+    err_msg = 'bar'
+    fun = lambda do
+      $stdout.write $stdin.read
+      $stderr.write err_msg
+    end
+    out_actual, err_actual = nil, nil
+    cid, stdin, stdout, stderr = pfork4 fun
+    stdin.write via_msg
+    stdin.close
+    out_actual = stdout.read
+    err_actual = stderr.read
+    assert_equal via_msg, out_actual
+    assert_equal err_msg, err_actual
+    assert_equal 0, wait_status(cid)
+  end
+
+  def test_io_pipes_with_block
+    via_msg = 'foo'
+    err_msg = 'bar'
+    fun = lambda do
+      $stdout.write $stdin.read
+      $stderr.write err_msg
+    end
+    out_actual, err_actual = nil, nil
+    status = pfork4(fun) do |_, stdin, stdout, stderr|
+      stdin.write via_msg
+      stdin.close
+      out_actual = stdout.read
+      err_actual = stderr.read
+    end
+    assert_equal via_msg, out_actual
+    assert_equal err_msg, err_actual
+    assert_equal 0, status.exitstatus
+  end
+
+  def test_exec_in_fun
+    via_msg = 'foo'
+    fun = lambda { exec %{ruby -e "print '#{via_msg}'"} }
+    out_actual = nil
+    status = pfork4(fun) do |_, stdin, stdout, _|
+      stdin.close
+      out_actual = stdout.read
+    end
+    assert_equal via_msg, out_actual
+    assert_equal 0, status.exitstatus
+  end
+
+  def test_io_pipes_and_then_exception_propagation_with_block
+    via_msg = 'foo'
+    err_msg = 'bar'
+    fun = lambda do
+      $stdout.write $stdin.read
+      $stderr.write err_msg
+      raise MyError
+    end
+    out_actual, err_actual = nil, nil
+    assert_raises(MyError) do
+      pfork4(fun) do |_, stdin, stdout, stderr|
+        stdin.write via_msg
+        stdin.close
+        out_actual = stdout.read
+        err_actual = stderr.read
+      end
+    end
+    assert_equal via_msg, out_actual
+    assert_equal err_msg, err_actual
+  end
+
+  def test_blocked_on_io_read_and_exception_propagation_with_block
+    fun = lambda do
+      $stdin.read
+      raise MyError
+    end
+    out_actual, err_actual = nil, nil
+    assert_raises(MyError) do
+      pfork4(fun) do |_, stdin, stdout, stderr|
+        stdin.write 'foo'
+        stdin.close
+        out_actual = stdout.read
+        err_actual = stderr.read
+      end
+    end
+    assert_equal '', out_actual
+    assert_equal '', err_actual
+  end
+end
+
+end

--- a/test/pfork4_test.rb
+++ b/test/pfork4_test.rb
@@ -34,6 +34,12 @@ class PFork4Test < TestCase
     assert_raises(MyError) { pfork4(fun) {} }
   end
 
+  def test_fun_propagate_exception_with_block_avoids_zombie_child_process
+    fun = lambda { raise MyError }
+    assert_raises(MyError) { pfork4(fun) {} }
+    assert_empty Process.waitall
+  end
+
   def test_call_block_upon_exception
     fun = lambda { raise MyError }
     block_called = false

--- a/test/popen4_test.rb
+++ b/test/popen4_test.rb
@@ -1,0 +1,75 @@
+require 'test_case'
+
+module Open4
+
+class POpen4Test < TestCase
+  def test_unknown_command_propagates_exception
+    unknown_cmd = 'asdfadsfjlkkk'
+    err = assert_raises(Errno::ENOENT, Errno::EINVAL) { popen4 unknown_cmd }
+    assert_match /#{unknown_cmd}/, err.to_s if on_mri?
+  end
+
+  def test_exit_failure
+    code = 43
+    cid, _ = popen4 %{ruby -e "exit #{43}"}
+    assert_equal code, wait_status(cid)
+  end
+
+  def test_exit_success
+    cid, _ = popen4 %{ruby -e "exit"}
+    assert_equal 0, wait_status(cid)
+  end
+
+  def test_passes_child_pid_to_block
+    cmd = %{ruby -e "STDOUT.print Process.pid"}
+    cid_in_block = nil
+    cid_in_fun = nil
+    status = popen4(cmd) do |cid, _, stdout, _|
+      cid_in_block = cid
+      cid_in_fun = stdout.read.to_i
+    end
+    assert_equal cid_in_fun, cid_in_block
+  end
+
+  def test_io_pipes_without_block
+    via_msg = 'foo'
+    err_msg = 'bar'
+    cmd = <<-END
+ruby -e "
+  STDOUT.write STDIN.read
+  STDERR.write '#{err_msg}'
+"
+    END
+    cid, stdin, stdout, stderr = popen4 cmd
+    stdin.write via_msg
+    stdin.close
+    out_actual = stdout.read
+    err_actual = stderr.read
+    assert_equal via_msg, out_actual
+    assert_equal err_msg, err_actual
+    assert_equal 0, wait_status(cid)
+  end
+
+  def test_io_pipes_with_block
+    via_msg = 'foo'
+    err_msg = 'bar'
+    out_actual, err_actual = nil
+    cmd = <<-END
+ruby -e "
+  STDOUT.write STDIN.read
+  STDERR.write '#{err_msg}'
+"
+    END
+    status = popen4(cmd) do |_, stdin, stdout, stderr|
+      stdin.write via_msg
+      stdin.close
+      out_actual = stdout.read
+      err_actual = stderr.read
+    end
+    assert_equal via_msg, out_actual
+    assert_equal err_msg, err_actual
+    assert_equal 0, status.exitstatus
+  end
+end
+
+end

--- a/test/popen4_test.rb
+++ b/test/popen4_test.rb
@@ -3,10 +3,17 @@ require 'test_case'
 module Open4
 
 class POpen4Test < TestCase
+  UNKNOWN_CMD = 'asdfadsfjlkkk'
+  UNKNOWN_CMD_ERRORS = [Errno::ENOENT, Errno::EINVAL]
+
   def test_unknown_command_propagates_exception
-    unknown_cmd = 'asdfadsfjlkkk'
-    err = assert_raises(Errno::ENOENT, Errno::EINVAL) { popen4 unknown_cmd }
-    assert_match /#{unknown_cmd}/, err.to_s if on_mri?
+    err = assert_raises(*UNKNOWN_CMD_ERRORS) { popen4 UNKNOWN_CMD }
+    assert_match /#{UNKNOWN_CMD}/, err.to_s if on_mri?
+  end
+
+  def test_exception_propagation_avoids_zombie_child_process
+    assert_raises(*UNKNOWN_CMD_ERRORS) { popen4 UNKNOWN_CMD }
+    assert_empty Process.waitall
   end
 
   def test_exit_failure

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -1,0 +1,23 @@
+# coding: utf-8
+
+require 'minitest/autorun'
+require 'open4'
+require 'rbconfig'
+
+module Open4
+  class TestCase < MiniTest::Unit::TestCase
+    include Open4
+
+    # Custom exception class for tests so we don't shadow possible
+    # programming errors.
+    class MyError < RuntimeError; end
+
+    def on_mri?
+      ::Config::CONFIG['ruby_install_name'] == 'ruby'
+    end
+
+    def wait_status(cid)
+      Process.waitpid2(cid).last.exitstatus
+    end
+  end
+end


### PR DESCRIPTION
`pfork4` is like `popen4`, but instead of executing command line, it calls arbitrary Ruby code in a child process. If `pfork4` is called with a block, it propagates any exception raised in the child process to the parent.

This patch includes tests for `popen4` and `pfork4`.

Tested with the following Ruby implementations:
- MRI 1.8.7-p352
- MRI 1.9.2-p290
- Rubinius head (2.0.0dev -- 1.8.7 2fcfbd1f)

Platform: OSX 10.6.8

Tests can be executed with `rake test`. Tests require MiniTest gem.

All the tests pass with MRI 1.8.7 and 1.9.2. They pass with Rubinius head as well, but with two special considerations:
- the system exception raised upon unknown command to `popen4` is different (MRI has `Errno::ENOENT`, Rubinius has `Errno::EINVAL`)
- `Exception#to_s` (and `#message`) print the name of the exception class on Rubinius, not the original message string given when raising the exception

The tests take the above into account.

The modified version of Open4 seems to run with the existing code samples (in `samples` directory) similarly to the master version.

The following samples work with MRI 1.8.7, 1.9.2, and Rubinius:
- `bg.rb`
- `block.rb`
- `exception.rb`
- `pfork4.rb` (new)
- `simple.rb`
- `spawn.rb`

The following samples work with MRI 1.8.7, but cause deadlock with MRI 1.9.2 and crash with Rubinius head.
- `stdin_timeout.rb`
- `timeout.rb`
