### PR TITLE
Add close_fds option to spawn.

### DIFF
--- a/lib/open4.rb
+++ b/lib/open4.rb
@@ -308,6 +308,7 @@ module Open4
     stderr_timeout = getopt[ %w( stderr_timeout ) ]
     status = getopt[ %w( status ) ]
     cwd = getopt[ %w( cwd dir ) ]
+    closefds = getopt[ %w( close_fds ) ]
 
     exitstatus =
       case exitstatus
@@ -328,7 +329,7 @@ module Open4
       begin
         chdir(cwd) do
           Timeout::timeout(timeout) do
-            popen4(*argv) do |c, i, o, e|
+            popen4ext(closefds, *argv) do |c, i, o, e|
               started = true
 
               %w( replace pid= << push update ).each do |msg|


### PR DESCRIPTION
The close-filedescriptors is great functionality, so this change makes it available to users of Open4::spawn too.
