### PR TITLE
use underscore instead of unused variable

### DIFF
--- a/lib/open4.rb
+++ b/lib/open4.rb
@@ -222,7 +222,7 @@ module Open4
 
   def getopts opts = {}
     lambda do |*args|
-      keys, default, ignored = args
+      keys, default, _ = args
       catch(:opt) do
         [keys].flatten.each do |key|
           [key, key.to_s, key.to_s.intern].each do |key|


### PR DESCRIPTION
Ruby 2.1.0 or later warned unused variable with -w option. I fixed it by using to underscore. 
