### PR TITLE
Add encoding option to open4

### DIFF
--- a/test/popen4_test.rb
+++ b/test/popen4_test.rb
@@ -56,6 +56,30 @@ ruby -e "
     assert_equal err_msg, err_actual
     assert_equal 0, wait_status(cid)
   end
+  
+  def test_io_pipes_encoding
+     via_msg = "I'm so \xF0\x9F\x98\x82"
+     via_msg.force_encoding('ASCII-8BIT')
+     err_msg = "Errors make me \xF0\x9F\x98\xA0"
+     err_msg.force_encoding('ASCII-8BIT')
+  
+     cmd = <<-END
+ ruby -e "
+   STDOUT.write STDIN.read
+   STDERR.write '#{err_msg}'
+ "
+     END
+     cid, stdin, stdout, stderr = popen4 cmd, "ASCII-8BIT"
+     stdin.write via_msg
+     stdin.close
+     out_actual = stdout.read
+     err_actual = stderr.read
+     assert_equal via_msg, out_actual
+     assert_equal err_msg, err_actual
+     assert_equal 0, wait_status(cid)
+	  assert_equal out_actual.encoding, Encoding.find("ASCII-8BIT")
+  end
+	  
 
   def test_io_pipes_with_block
     via_msg = 'foo'

--- a/test/popen4ext_test.rb
+++ b/test/popen4ext_test.rb
@@ -8,23 +8,23 @@ class POpen4Test < TestCase
   UNKNOWN_CMD_ERRORS = [Errno::ENOENT, Errno::EINVAL]
 
   def test_unknown_command_propagates_exception
-    err = assert_raises(*UNKNOWN_CMD_ERRORS) { popen4ext true, UNKNOWN_CMD }
+    err = assert_raises(*UNKNOWN_CMD_ERRORS) { popen4ext UNKNOWN_CMD, true }
     assert_match(/#{UNKNOWN_CMD}/, err.to_s) if on_mri?
   end
 
   def test_exception_propagation_avoids_zombie_child_process
-    assert_raises(*UNKNOWN_CMD_ERRORS) { popen4ext true, UNKNOWN_CMD }
+    assert_raises(*UNKNOWN_CMD_ERRORS) { popen4ext UNKNOWN_CMD, true }
     assert_empty Process.waitall
   end
 
   def test_exit_failure
     code = 43
-    cid, _ = popen4ext true, %{ruby -e "exit #{43}"}
+    cid, _ = popen4ext %{ruby -e "exit #{43}"}, true
     assert_equal code, wait_status(cid)
   end
 
   def test_exit_success
-    cid, _ = popen4ext true, %{ruby -e "exit"}
+    cid, _ = popen4ext %{ruby -e "exit"}, true
     assert_equal 0, wait_status(cid)
   end
 
@@ -32,7 +32,7 @@ class POpen4Test < TestCase
     cmd = %{ruby -e "STDOUT.print Process.pid"}
     cid_in_block = nil
     cid_in_fun = nil
-    popen4ext(true, cmd) do |cid, _, stdout, _|
+    popen4ext(cmd, true) do |cid, _, stdout, _|
       cid_in_block = cid
       cid_in_fun = stdout.read.to_i
     end
@@ -48,7 +48,7 @@ ruby -e "
   STDERR.write '#{err_msg}'
 "
     END
-    cid, stdin, stdout, stderr = popen4ext true, cmd
+    cid, stdin, stdout, stderr = popen4ext cmd, true
     stdin.write via_msg
     stdin.close
     out_actual = stdout.read
@@ -68,7 +68,7 @@ ruby -e "
   STDERR.write '#{err_msg}'
 "
     END
-    status = popen4ext(true, cmd) do |_, stdin, stdout, stderr|
+    status = popen4ext(cmd, true) do |_, stdin, stdout, stderr|
       stdin.write via_msg
       stdin.close
       out_actual = stdout.read
@@ -81,7 +81,7 @@ ruby -e "
 
   def test_close_ignores_errors
     TCPSocket.new('localhost', 59367).close rescue nil
-    cid, _ = popen4ext true, %{ruby -e "exit"}
+    cid, _ = popen4ext %{ruby -e "exit"}, true
     assert_equal 0, wait_status(cid)
   end
 end


### PR DESCRIPTION
Hi there,

We use open4 to generate various images from raw PDF data via an external command which involves a lot of binary data. We ran into issues with string encoding when using open4, so I've added an option to #popen4, #pork4, and #popen4ext.

The change to #popen4ext has re-ordered it's arguments, and I've also changed the *cmd argument to just cmd (removed the splat), but you can still pass an array of command parameters as the first argument.

I realise this changes the public API, but I thought the encoding options might be of interest. Happy to update with suggestions of different ways to set the encoding but maintain the current public API.
