### PR TITLE
Test: use recent Minitest style

### DIFF
--- a/test/lib/test_case.rb
+++ b/test/lib/test_case.rb
@@ -5,7 +5,7 @@ require 'open4'
 require 'rbconfig'
 
 module Open4
-  class TestCase < MiniTest::Unit::TestCase
+  class TestCase < Minitest::Test
     include Open4
 
     # Custom exception class for tests so we don't shadow possible


### PR DESCRIPTION
Current style has long been to use Minitest instead of MiniTest at least for 3 years, and with minitest 5.19, MiniTest usage support is hidden unless explicitly setting ENV["MT_COMPAT"].

https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6

Use Minitest::Test instead of MiniTest::Unit::TestCase .